### PR TITLE
Fixes SMS intent and call intent

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -13,6 +13,12 @@
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
+        <option name="myModules">
+          <set>
+            <option value="$PROJECT_DIR$" />
+            <option value="$PROJECT_DIR$/app" />
+          </set>
+        </option>
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -4,6 +4,8 @@
     <modules>
       <module fileurl="file://$PROJECT_DIR$/PRacticeSet5.iml" filepath="$PROJECT_DIR$/PRacticeSet5.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
+      <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
+      <module fileurl="file://$PROJECT_DIR$/summer-of-code-app.iml" filepath="$PROJECT_DIR$/summer-of-code-app.iml" />
     </modules>
   </component>
 </project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>

--- a/app/src/main/java/com/example/practiceset5/pset11.java
+++ b/app/src/main/java/com/example/practiceset5/pset11.java
@@ -1,10 +1,15 @@
 package com.example.practiceset5;
 
+import android.Manifest;
 import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.pm.PackageManager;
+import android.support.annotation.NonNull;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.telephony.SmsManager;
@@ -28,6 +33,8 @@ public class pset11 extends AppCompatActivity {
     PendingIntent pidel;
     IntentFilter infdel;
     String sms_del="Message delivered";
+
+    private static int SMS_SEND_PERMISSION = 123;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -89,10 +96,28 @@ public class pset11 extends AppCompatActivity {
         editText2 = (EditText)findViewById(R.id.editTextMessage);
         String mobileNumber = editText1.getText().toString();
         String message = editText2.getText().toString();
-        SmsManager sms = SmsManager.getDefault();
-        sms.sendTextMessage(mobileNumber, null, message, null, null);
-        Toast.makeText(getApplicationContext(),"SMS_SENT",Toast.LENGTH_SHORT).show();
-        Toast.makeText(getApplicationContext(),"SMS_DELIVERED",Toast.LENGTH_SHORT).show();
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.SEND_SMS) != PackageManager.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions(this, new String[] {Manifest.permission.SEND_SMS}, SMS_SEND_PERMISSION);
+        } else {
+            try {
+                SmsManager sms = SmsManager.getDefault();
+                sms.sendTextMessage(mobileNumber, null, message, null, null);
+                Toast.makeText(getApplicationContext(), "SMS_SENT", Toast.LENGTH_SHORT).show();
+                Toast.makeText(getApplicationContext(), "SMS_DELIVERED", Toast.LENGTH_SHORT).show();
+            } catch (NullPointerException e) {
+                Toast.makeText(getApplicationContext(), "Invalid phone number", Toast.LENGTH_SHORT).show();
+            }
+        }
     }
 
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        if (requestCode == SMS_SEND_PERMISSION) {
+            if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                Toast.makeText(getApplicationContext(),"SMS sending permission granted. Click the button again.",Toast.LENGTH_SHORT).show();
+            } else {
+                Toast.makeText(getApplicationContext(),"SMS sending permission denied.",Toast.LENGTH_SHORT).show();
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/example/practiceset5/pset16.java
+++ b/app/src/main/java/com/example/practiceset5/pset16.java
@@ -34,7 +34,7 @@ public class pset16 extends AppCompatActivity {
         //noinspection SimplifiableIfStatement
         if (id == R.id.action_contact) {
             Intent i = new Intent();
-            i.setAction(Intent.ACTION_CALL);
+            i.setAction(Intent.ACTION_DIAL);
             i.setData(Uri.parse("tel:121"));
             startActivity(i);
         }

--- a/app/src/main/java/com/example/practiceset5/pset4.java
+++ b/app/src/main/java/com/example/practiceset5/pset4.java
@@ -27,7 +27,7 @@ public class pset4 extends AppCompatActivity {
 
     public void callnum(View v){
         Intent i = new Intent();
-        i.setAction(Intent.ACTION_CALL);
+        i.setAction(Intent.ACTION_DIAL);
         i.setData(Uri.parse("tel:121"));
         startActivity(i);
     }


### PR DESCRIPTION
Fixed issue #1 
- From SDK version 23 onwards, Android requires runtime permission to send SMS, which has been fixed
- Also fixed the calling intent by changing `ACTION_CALL` to `ACTION_DIAL`
